### PR TITLE
fix/hub

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,7 +4,6 @@
 package gosocket
 
 import (
-	"encoding/json"
 	"errors"
 	"sync"
 )
@@ -13,28 +12,22 @@ import (
 // It defines the methods that a client must implement to interact with the server.
 type IClient interface {
 	// Send sends a raw byte message to the server.
-	// The message is sent as-is, without any encoding or processing.
-	Send(message []byte) error
+	Send(message *Message) error
 
-	// SendMessage sends a message to the server, with the option to specify encoding.
-	// The message is sent with the specified encoding, if any.
-	SendMessage(message *Message) error
-
-	// SendData sends arbitrary data to the server, automatically encoding it as JSON.
-	// The data is marshaled to JSON and sent to the server.
-	SendData(data interface{}) error
-
-	// SendDataWithEncoding sends arbitrary data to the server with a specified encoding.
-	// The data is marshaled to the specified encoding and sent to the server.
-	SendDataWithEncoding(data interface{}, encoding EncodingType) error
+	// SendTo sends a message to a specific client.
+	SendTo(id string, message *Message) error
 
 	// SendJSON sends JSON-encoded data to the server.
-	// The data is marshaled to JSON and sent to the server.
 	SendJSON(data interface{}) error
 
 	// SendProtobuf sends Protobuf-encoded data to the server.
-	// The data is marshaled to Protobuf and sent to the server.
 	SendProtobuf(data interface{}) error
+
+	// Send sends a raw byte message to the server.
+	// The message is sent as-is, without any encoding or processing.
+	SendRaw(message []byte) error
+
+	BroadcastToRoom(room string, message *Message) error
 
 	// JoinRoom joins a specific room on the server.
 	// The client becomes a member of the specified room.
@@ -67,7 +60,7 @@ type IClient interface {
 type Client struct {
 	ID          string
 	Conn        IWebSocketConn // WebSocket connection (gorilla/websocket.Conn)
-	MessageChan chan []byte
+	MessageChan chan *Message
 	Hub         IHub
 	UserData    map[string]interface{} // user custom data
 	ConnInfo    *ConnectionInfo
@@ -90,7 +83,7 @@ func NewClient(id string, conn IWebSocketConn, hub IHub, messageChanBufSize int)
 		ID:          id,
 		Conn:        conn,
 		Hub:         hub,
-		MessageChan: make(chan []byte, messageChanBufSize),
+		MessageChan: make(chan *Message, messageChanBufSize),
 		UserData:    make(map[string]interface{}),
 		ConnInfo:    nil, // will be defined at HandleWebSocket
 	}
@@ -100,103 +93,13 @@ func NewClient(id string, conn IWebSocketConn, hub IHub, messageChanBufSize int)
 // channel is not full. If the channel is full, it will return an error.
 //
 // This method is safe to call concurrently.
-func (c *Client) Send(message []byte) error {
-	defer func() {
-		if r := recover(); r != nil {
-			c.Hub.Log(LogTypeClient, LogLevelError, "PANIC RECOVERED in Client.Send (ID: %s): %v", c.ID, r)
-		}
-	}()
-
-	c.mu.Lock()
-	if c.Conn == nil {
-		c.mu.Unlock()
-		c.Hub.Log(LogTypeClient, LogLevelError, "Client.Send (ID: %s): Connection is nil", c.ID)
-		return ErrClientConnNil
-	}
-	c.mu.Unlock()
-
-	select {
-	case c.MessageChan <- message:
-		return nil
-	default:
-		c.Hub.Log(LogTypeClient, LogLevelError, "Client.Send (ID: %s): Message channel is full", c.ID)
-		safeGoroutine("Client.Disconnect", func() {
-			_ = c.Disconnect()
-		})
-		return ErrClientFull
-	}
+func (c *Client) Send(message *Message) error {
+	return c.Hub.SendToClient(c.ID, c.ID, message)
 }
 
-// SendMessage sends a message to the client.
-//
-// If the message has a RawData field that is not nil, it will be sent directly.
-// Otherwise, the Data field will be sent with the Encoding specified in the
-// message. If the Encoding field is 0, it will be assumed to be JSON.
-//
-// The SendJSON and Send methods will be used to send the message.
-//
-// If the message has no data to send, an error will be returned.
-//
-// This method is safe to call concurrently.
-func (c *Client) SendMessage(message *Message) error {
-	if message.RawData != nil {
-		return c.Send(message.RawData)
-	}
-
-	if message.Data != nil {
-		// JSON fallback
-		if message.Encoding == 0 {
-			c.Hub.Log(LogTypeClient, LogLevelDebug, "Client.SendMessage (ID: %s): Encoding not specified, assuming JSON", c.ID)
-			message.Encoding = JSON
-		}
-
-		switch message.Encoding {
-		case JSON:
-			return c.SendJSON(message.Data)
-		case Raw:
-			if rawData, ok := message.Data.([]byte); ok {
-				return c.Send(rawData)
-			}
-			return ErrRawEncoding
-		default:
-			c.Hub.Log(LogTypeClient, LogLevelError, "Client.SendMessage (ID: %s): Unsupported encoding: %s", c.ID, message.Encoding)
-			return newUnsupportedEncodingError(message.Encoding)
-		}
-	}
-
-	return ErrNoDataToSend
-}
-
-// SendData sends the given data to the client. It will be sent as JSON if no encoding type is specified.
-//
-// This method is safe to call concurrently.
-func (c *Client) SendData(data interface{}) error {
-	return c.SendJSON(data) // JSON by default
-}
-
-// SendDataWithEncoding sends the given data to the client using the specified
-// encoding type.
-//
-// If the encoding type is JSON, it will be sent as JSON.
-// If the encoding type is Raw, it will be sent directly as a byte slice. If the
-// data is not a byte slice, an error will be returned.
-//
-// If the encoding type is not supported, an error will be returned.
-//
-// This method is safe to call concurrently.
-func (c *Client) SendDataWithEncoding(data interface{}, encoding EncodingType) error {
-	switch encoding {
-	case JSON:
-		return c.SendJSON(data)
-	case Raw:
-		if rawData, ok := data.([]byte); ok {
-			return c.Send(rawData)
-		}
-		return ErrRawEncoding
-	default:
-		c.Hub.Log(LogTypeClient, LogLevelError, "Client.SendDataWithEncoding (ID: %s): Unsupported encoding: %s", c.ID, encoding)
-		return newUnsupportedEncodingError(encoding)
-	}
+// SendTo sends a message to a specific client.
+func (c *Client) SendTo(id string, message *Message) error {
+	return c.Hub.SendToClient(c.ID, id, message)
 }
 
 // SendJSON sends the given data to the client as JSON.
@@ -208,11 +111,11 @@ func (c *Client) SendDataWithEncoding(data interface{}, encoding EncodingType) e
 //
 // This method is safe to call concurrently.
 func (c *Client) SendJSON(data interface{}) error {
-	jsonData, err := json.Marshal(data)
-	if err != nil {
-		return newSerializeError(err)
-	}
-	return c.Send(jsonData)
+	return c.Send(&Message{
+		Data:     data,
+		Type:     TextMessage,
+		Encoding: JSON,
+	})
 }
 
 // SendProtobuf sends the given data to the client as a Protobuf message.
@@ -226,27 +129,37 @@ func (c *Client) SendProtobuf(data interface{}) error {
 	return errors.New("protobuf serialization not yet implemented")
 }
 
+// SendRaw sends the given raw data to the client.
+//
+// This method is safe to call concurrently.
+func (c *Client) SendRaw(data []byte) error {
+	return c.Send(&Message{
+		RawData:  data,
+		Type:     BinaryMessage,
+		Encoding: Raw,
+	})
+}
+
 // JoinRoom joins the given room. It will return an error if the client's hub is
 // nil. Otherwise, it will call the hub's JoinRoom method with the client and room.
 //
 // This method is safe to call concurrently.
-func (c *Client) JoinRoom(roomName string) error {
+func (c *Client) JoinRoom(roomId string) error {
 	if c.Hub == nil {
 		return ErrHubIsNil
 	}
-	c.Hub.JoinRoom(c, roomName)
-	return nil
+	return c.Hub.JoinRoom(c, roomId)
 }
 
 // LeaveRoom leaves the given room. It will return an error if the client's hub is
 // nil. Otherwise, it will call the hub's LeaveRoom method with the client and room.
 //
 // This method is safe to call concurrently.
-func (c *Client) LeaveRoom(room string) error {
+func (c *Client) LeaveRoom(roomId string) error {
 	if c.Hub == nil {
 		return ErrHubIsNil
 	}
-	c.Hub.LeaveRoom(c, room)
+	c.Hub.LeaveRoom(c, roomId)
 	return nil
 }
 

--- a/client.go
+++ b/client.go
@@ -262,8 +262,8 @@ func (c *Client) GetRooms() []string {
 
 	var rooms []string
 	for _, room := range c.Hub.GetRooms() {
-		if _, exists := room.Clients.GetByStringId(c.ID); exists {
-			rooms = append(rooms, room.Name)
+		if _, exists := room.GetClient(c.ID); exists {
+			rooms = append(rooms, room.Name())
 		}
 	}
 	return rooms

--- a/errors.go
+++ b/errors.go
@@ -81,10 +81,6 @@ var (
 	ErrUnsupportedEncoding = errors.New("unsupported encoding")
 )
 
-func newUnsupportedEncodingError(encoding EncodingType) error {
-	return fmt.Errorf("%w: %d", ErrUnsupportedEncoding, encoding)
-}
-
 func newSerializeError(err error) error {
 	return fmt.Errorf("%w: %w", ErrSerializeData, err)
 }

--- a/errors.go
+++ b/errors.go
@@ -24,10 +24,11 @@ var (
 	ErrMaxBinarySizeLessThanOne  = errors.New("max binary size must be greater than 0")
 
 	// Client errors
-	ErrClientConnNil  = errors.New("client connection is nil")
-	ErrNoDataToSend   = errors.New("message has no data to send")
-	ErrClientFull     = errors.New("client message channel is full")
-	ErrClientNotFound = errors.New("client not found")
+	ErrClientConnNil   = errors.New("client connection is nil")
+	ErrNoDataToSend    = errors.New("message has no data to send")
+	ErrClientFull      = errors.New("client message channel is full")
+	ErrClientNotFound  = errors.New("client not found")
+	ErrInvalidClientId = errors.New("invalid client id")
 
 	// Server errors
 	ErrServerAlreadyRunning = errors.New("server is already running")
@@ -42,6 +43,7 @@ var (
 	ErrSendMessage       = errors.New("failed to send message")
 	ErrEventFailed       = errors.New("event failed")
 	ErrAuthFailure       = errors.New("authentication failed")
+	ErrClientIdGenerator = errors.New("client id generator failed")
 	ErrTooManyRequests   = errors.New("too many requests")
 	ErrRateLimitExceeded = errors.New("rate limit exceeded")
 
@@ -133,6 +135,10 @@ func newInvalidPortError(port int) error {
 
 func newAuthFailureError(err error) error {
 	return fmt.Errorf("%w: %w", ErrAuthFailure, err)
+}
+
+func newClientIdGeneratorError(err error) error {
+	return fmt.Errorf("%w: %w", ErrClientIdGenerator, err)
 }
 
 func newMaxDepthExceededError(val int) error {

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -264,7 +264,7 @@ func handleChatMessage(client *gosocket.Client, msg *ChatMessage, ctx *gosocket.
 }
 
 func broadcastUserList(ctx *gosocket.Context, room string) {
-	clients := ctx.Hub().GetRoomClients(room)
+	clients := ctx.Hub().GetClientsInRoom(room)
 	var users []string
 
 	for _, client := range clients {

--- a/gosocket.go
+++ b/gosocket.go
@@ -183,6 +183,21 @@ func WithAuth(authFunc AuthFunc) UniversalOption {
 	}
 }
 
+// WithCustomClientID sets a custom client ID generator for a handler. The
+// generator will be called with the original request and associated user data
+// (from authentication, if any) when a new client connects to the handler.
+// If the generator returns an error, the connection will be rejected with HTTP 500.
+// If the generator returns an empty string, the connection will also be rejected.
+// The generator is called after authentication but before the WebSocket upgrade
+// and OnConnect handler, allowing the OnConnect handler to access the generated
+// client ID through the Client object.
+func WithCustomClientID(generator ClientIdGenerator) UniversalOption {
+	return func(h HasHandler) error {
+		h.Handler().clientIdGenerator = generator
+		return nil
+	}
+}
+
 func WithMaxDepth(depth int) UniversalOption {
 	return func(h HasHandler) error {
 		if depth < 1 {

--- a/handler.go
+++ b/handler.go
@@ -415,14 +415,47 @@ func (h *Handler) handleClientWrite(client *Client, handlerCtx *Context) {
 				return
 			}
 
-			if err := conn.WriteMessage(websocket.TextMessage, message); err != nil {
+			if message == nil {
+				h.log(LogTypeMessage, LogLevelError, "%s no message to send", client.ID)
+				return
+			}
+
+			var wsMessageType int
+			switch message.Type {
+			case BinaryMessage:
+				wsMessageType = websocket.BinaryMessage
+			case TextMessage:
+			default:
+				wsMessageType = websocket.TextMessage
+			}
+
+			if message.RawData == nil && message.Data != nil {
+				// serialize based on encode
+				data, err := h.serializeMessageWithEncoding(message)
+				if err != nil {
+					h.log(LogTypeMessage, LogLevelError, "%s serialization error: %v", client.ID, err)
+					if h.events.OnError != nil {
+						_ = h.events.OnError(client, newSerializeError(err), handlerCtx)
+					}
+					continue
+				}
+
+				message.RawData = data
+			}
+
+			if message.RawData == nil {
+				h.log(LogTypeMessage, LogLevelError, "%s no data to send", client.ID)
+				return
+			}
+
+			if err := conn.WriteMessage(wsMessageType, message.RawData); err != nil {
 				h.log(LogTypeMessage, LogLevelError, "%s write error: %v", client.ID, err)
 				if h.events.OnError != nil {
 					_ = h.events.OnError(client, err, handlerCtx)
 				}
 				return
 			}
-			h.log(LogTypeMessage, LogLevelDebug, "%s wrote: %s", client.ID, message)
+			h.log(LogTypeMessage, LogLevelDebug, "%s wrote message (type: %v, size: %d bytes)", client.ID, message.Type, len(message.RawData))
 
 		case <-ticker.C:
 			select {
@@ -697,6 +730,39 @@ func (h *Handler) log(logType LogType, level LogLevel, msg string, args ...inter
 	if level <= lvl {
 		h.logger.Logger.Log(logType, level, msg, args...)
 	}
+}
+
+func (h *Handler) serializeMessageWithEncoding(message *Message) ([]byte, error) {
+	switch message.Encoding {
+	case Protobuf:
+		if serializer := h.serializers[Protobuf]; serializer != nil {
+			if protoData, err := serializer.Marshal(message.Data); err == nil {
+				return protoData, nil
+			} else {
+				return nil, newSerializeError(err)
+			}
+		}
+	case Raw:
+		if rawData, ok := message.Data.([]byte); ok {
+			return rawData, nil
+		} else {
+			return nil, ErrRawEncoding
+		}
+	case JSON:
+		if serializer := h.serializers[JSON]; serializer != nil {
+			return serializer.Marshal(message.Data)
+		}
+		fallthrough
+	default:
+		// fallback to JSON
+		if jsonData, err := json.Marshal(message.Data); err == nil {
+			return jsonData, nil
+		} else {
+			return nil, newSerializeError(err)
+		}
+	}
+
+	return nil, ErrSerializeData
 }
 
 // extractHeaders extracts relevant headers from the given http request.

--- a/integration_test.go
+++ b/integration_test.go
@@ -1150,8 +1150,8 @@ func TestIntegration_RoomsIsolation(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, _, _ = server.CreateRoom("room1")
-	_, _, _ = server.CreateRoom("room2")
+	_, _ = server.CreateRoom("room1")
+	_, _ = server.CreateRoom("room2")
 
 	ts := httptest.NewServer(server.handler)
 	defer ts.Close()
@@ -1874,8 +1874,8 @@ func TestIntegration_RoomEdgeCases(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, _, _ = server.CreateRoom("room1")
-	_, _, _ = server.CreateRoom("room2")
+	_, _ = server.CreateRoom("room1")
+	_, _ = server.CreateRoom("room2")
 
 	ts := httptest.NewServer(server.handler)
 	defer ts.Close()

--- a/integration_test.go
+++ b/integration_test.go
@@ -25,7 +25,7 @@ func TestIntegration_Echo(t *testing.T) {
 	server, err := NewServer(
 		WithPath("/ws"),
 		OnMessage(func(c *Client, m *Message, ctx *Context) error {
-			return c.Send(m.RawData)
+			return c.Send(m)
 		}),
 	)
 	require.NoError(t, err)
@@ -133,7 +133,7 @@ func TestIntegration_RapidMessages(t *testing.T) {
 			MaxRateLimitViolations: 3000,
 		}),
 		OnMessage(func(c *Client, m *Message, ctx *Context) error {
-			return c.Send(m.RawData)
+			return c.SendRaw(m.RawData)
 		}),
 	)
 	require.NoError(t, err)
@@ -184,7 +184,7 @@ func TestIntegration_ConcurrentClients(t *testing.T) {
 				mu.Unlock()
 				return nil
 			}
-			return c.Send(m.RawData)
+			return c.SendRaw(m.RawData)
 		}),
 		OnDisconnect(func(c *Client, ctx *Context) error {
 			mu.Lock()
@@ -549,7 +549,7 @@ func TestIntegration_LargeMessagesEcho(t *testing.T) {
 			MaxRateLimitViolations: 100,
 		}),
 		OnMessage(func(c *Client, m *Message, ctx *Context) error {
-			return c.Send(m.RawData)
+			return c.SendRaw(m.RawData)
 		}),
 	)
 	require.NoError(t, err)
@@ -1136,14 +1136,14 @@ func TestIntegration_RoomsIsolation(t *testing.T) {
 		WithPath("/ws"),
 		WithRelevantHeaders([]string{"Room"}),
 		OnConnect(func(c *Client, ctx *Context) error {
-			c.Hub.JoinRoom(c, ctx.connInfo.Headers["Room"])
+			_ = c.Hub.JoinRoom(c, ctx.connInfo.Headers["Room"])
 			return nil
 		}),
 		OnMessage(func(c *Client, m *Message, ctx *Context) error {
 			roomName := ctx.connInfo.Headers["Room"]
 			room := c.Hub.GetRooms()
 			if room != nil {
-				c.Hub.BroadcastToRoom(roomName, m)
+				_ = c.Hub.BroadcastToRoom(roomName, m)
 			}
 			return nil
 		}),
@@ -1236,7 +1236,7 @@ func TestIntegration_RateLimitingEnforced(t *testing.T) {
 		WithRateLimit(rlConfig),
 		OnMessage(func(c *Client, m *Message, ctx *Context) error {
 			// echo msg
-			return c.SendMessage(m)
+			return c.Send(m)
 		}),
 	)
 	require.NoError(t, err)
@@ -1365,7 +1365,7 @@ func TestIntegration_MessageTypes(t *testing.T) {
 			mu.Lock()
 			received[int(m.Type)] = m.RawData
 			mu.Unlock()
-			return c.Send(m.RawData)
+			return c.SendRaw(m.RawData)
 		}),
 	)
 	require.NoError(t, err)
@@ -1423,7 +1423,7 @@ func TestIntegration_JSONMessages(t *testing.T) {
 
 			msg.Data = "processed: " + msg.Data
 			response, _ := json.Marshal(msg)
-			return c.Send(response)
+			return c.SendRaw(response)
 		}),
 	)
 	require.NoError(t, err)
@@ -1475,7 +1475,7 @@ func TestIntegration_ErrorHandling(t *testing.T) {
 				atomic.AddInt32(&errorsCaught, 1)
 				return fmt.Errorf("message error")
 			}
-			return c.Send(m.RawData)
+			return c.SendRaw(m.RawData)
 		}),
 		OnError(func(c *Client, err error, ctx *Context) error {
 			atomic.AddInt32(&errorsCaught, 1)
@@ -1526,7 +1526,7 @@ func TestIntegration_MemoryLeaks(t *testing.T) {
 			MaxRateLimitViolations: 10000,
 		}),
 		OnMessage(func(c *Client, m *Message, ctx *Context) error {
-			return c.Send(m.RawData)
+			return c.SendRaw(m.RawData)
 		}),
 	)
 	require.NoError(t, err)
@@ -1644,7 +1644,7 @@ func TestIntegration_CustomHeadersValidation(t *testing.T) {
 			return nil
 		}),
 		OnMessage(func(c *Client, m *Message, ctx *Context) error {
-			return c.Send(m.RawData)
+			return c.SendRaw(m.RawData)
 		}),
 	)
 	require.NoError(t, err)
@@ -1704,7 +1704,7 @@ func TestIntegration_MultipleClientsWithDifferentHeaders(t *testing.T) {
 			return nil
 		}),
 		OnMessage(func(c *Client, m *Message, ctx *Context) error {
-			return c.Send(m.RawData)
+			return c.SendRaw(m.RawData)
 		}),
 	)
 	require.NoError(t, err)
@@ -1788,7 +1788,7 @@ func TestIntegration_IgnoredHeaders(t *testing.T) {
 			return nil
 		}),
 		OnMessage(func(c *Client, m *Message, ctx *Context) error {
-			return c.Send(m.RawData)
+			return c.SendRaw(m.RawData)
 		}),
 	)
 	require.NoError(t, err)
@@ -1841,7 +1841,7 @@ func TestIntegration_RoomEdgeCases(t *testing.T) {
 			switch parts[0] {
 			case "join":
 				if len(parts) > 1 {
-					c.Hub.JoinRoom(c, parts[1])
+					_ = c.Hub.JoinRoom(c, parts[1])
 					mu.Lock()
 					events = append(events, fmt.Sprintf("joined-%s", parts[1]))
 					mu.Unlock()
@@ -1855,7 +1855,7 @@ func TestIntegration_RoomEdgeCases(t *testing.T) {
 				}
 			case "broadcast":
 				if len(parts) > 2 {
-					c.Hub.BroadcastToRoom(parts[1], &Message{
+					_ = c.Hub.BroadcastToRoom(parts[1], &Message{
 						Type:    websocket.TextMessage,
 						RawData: []byte(parts[2]),
 					})
@@ -1867,7 +1867,7 @@ func TestIntegration_RoomEdgeCases(t *testing.T) {
 					roomNames = append(roomNames, room.name)
 				}
 				response := strings.Join(roomNames, ",")
-				return c.Send([]byte(response))
+				return c.SendRaw([]byte(response))
 			}
 			return nil
 		}),
@@ -1971,7 +1971,7 @@ func TestIntegration_ConnectionLimits(t *testing.T) {
 		WithPath("/ws"),
 		WithMaxConnections(maxConnections),
 		OnMessage(func(c *Client, m *Message, ctx *Context) error {
-			return c.Send(m.RawData)
+			return c.SendRaw(m.RawData)
 		}),
 	)
 	require.NoError(t, err)
@@ -2028,7 +2028,7 @@ func TestIntegration_AttachToCtx(t *testing.T) {
 		}),
 		OnMessage(func(c *Client, m *Message, ctx *Context) error {
 			require.Equal(t, "test_val", ctx.Context().Value(testKey))
-			return c.Send(m.RawData)
+			return c.SendRaw(m.RawData)
 		}),
 	)
 	require.NoError(t, err)

--- a/integration_test.go
+++ b/integration_test.go
@@ -1864,7 +1864,7 @@ func TestIntegration_RoomEdgeCases(t *testing.T) {
 				rooms := c.Hub.GetRooms()
 				roomNames := make([]string, 0, len(rooms))
 				for _, room := range rooms {
-					roomNames = append(roomNames, room.Name)
+					roomNames = append(roomNames, room.name)
 				}
 				response := strings.Join(roomNames, ",")
 				return c.Send([]byte(response))

--- a/integration_test.go
+++ b/integration_test.go
@@ -1150,8 +1150,8 @@ func TestIntegration_RoomsIsolation(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, _ = server.CreateRoom("room1")
-	_, _ = server.CreateRoom("room2")
+	_, _, _ = server.CreateRoom("room1")
+	_, _, _ = server.CreateRoom("room2")
 
 	ts := httptest.NewServer(server.handler)
 	defer ts.Close()
@@ -1874,8 +1874,8 @@ func TestIntegration_RoomEdgeCases(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, _ = server.CreateRoom("room1")
-	_, _ = server.CreateRoom("room2")
+	_, _, _ = server.CreateRoom("room1")
+	_, _, _ = server.CreateRoom("room2")
 
 	ts := httptest.NewServer(server.handler)
 	defer ts.Close()

--- a/room.go
+++ b/room.go
@@ -4,17 +4,23 @@
 package gosocket
 
 type Room struct {
+	id      string
 	ownerId string
 	name    string
-	clients *SharedCollection[*Client]
+	clients *SharedCollection[*Client, string]
 }
 
-func NewRoom(ownerId, name string) *Room {
+func NewRoom(id, ownerId, name string) *Room {
 	return &Room{
+		id:      id,
 		ownerId: ownerId,
 		name:    name,
-		clients: NewSharedCollection[*Client](),
+		clients: NewSharedCollection[*Client, string](),
 	}
+}
+
+func (r *Room) ID() string {
+	return r.id
 }
 
 func (r *Room) Name() string {
@@ -25,18 +31,18 @@ func (r *Room) OwnerId() string {
 	return r.ownerId
 }
 
-func (r *Room) Clients() map[uint64]*Client {
+func (r *Room) Clients() map[string]*Client {
 	return r.clients.GetAll()
 }
 
 func (r *Room) AddClient(client *Client) {
-	r.clients.AddWithStringId(client, client.ID)
+	r.clients.Add(client, client.ID)
 }
 
 func (r *Room) RemoveClient(id string) bool {
-	return r.clients.RemoveByStringId(id)
+	return r.clients.Remove(id)
 }
 
 func (r *Room) GetClient(id string) (*Client, bool) {
-	return r.clients.GetByStringId(id)
+	return r.clients.Get(id)
 }

--- a/room.go
+++ b/room.go
@@ -4,15 +4,39 @@
 package gosocket
 
 type Room struct {
-	OwnerId string
-	Name    string
-	Clients *SharedCollection[*Client]
+	ownerId string
+	name    string
+	clients *SharedCollection[*Client]
 }
 
 func NewRoom(ownerId, name string) *Room {
 	return &Room{
-		OwnerId: ownerId,
-		Name:    name,
-		Clients: NewSharedCollection[*Client](),
+		ownerId: ownerId,
+		name:    name,
+		clients: NewSharedCollection[*Client](),
 	}
+}
+
+func (r *Room) Name() string {
+	return r.name
+}
+
+func (r *Room) OwnerId() string {
+	return r.ownerId
+}
+
+func (r *Room) Clients() map[uint64]*Client {
+	return r.clients.GetAll()
+}
+
+func (r *Room) AddClient(client *Client) {
+	r.clients.AddWithStringId(client, client.ID)
+}
+
+func (r *Room) RemoveClient(id string) bool {
+	return r.clients.RemoveByStringId(id)
+}
+
+func (r *Room) GetClient(id string) (*Client, bool) {
+	return r.clients.GetByStringId(id)
 }

--- a/server.go
+++ b/server.go
@@ -490,9 +490,9 @@ func (s *Server) BroadcastToRoomProtobuf(room string, data interface{}) error {
 
 // GetClients returns all clients currently connected to the server. If the server is not properly
 // initialized, an empty slice is returned.
-func (s *Server) GetClients() map[uint64]*Client {
+func (s *Server) GetClients() map[string]*Client {
 	if s.handler == nil || s.handler.Hub() == nil {
-		return map[uint64]*Client{}
+		return map[string]*Client{}
 	}
 
 	return s.handler.Hub().GetClients()
@@ -512,9 +512,9 @@ func (s *Server) GetClient(id string) *Client {
 // GetClientsInRoom returns all clients in the specified room. If the server is not properly
 // initialized or the room does not exist, an empty slice is returned. This method is safe to call
 // concurrently.
-func (s *Server) GetClientsInRoom(room string) map[uint64]*Client {
+func (s *Server) GetClientsInRoom(room string) map[string]*Client {
 	if s.handler == nil || s.handler.Hub() == nil {
-		return map[uint64]*Client{}
+		return map[string]*Client{}
 	}
 
 	return s.handler.Hub().GetClientsInRoom(room)
@@ -550,9 +550,9 @@ func (s *Server) DisconnectClient(id string) error {
 // will return nil. If the server is not properly initialized, an error is returned.
 //
 // Thismethod is safe to call concurrently.
-func (s *Server) CreateRoom(name string) (*Room, uint64, error) {
+func (s *Server) CreateRoom(name string) (*Room, error) {
 	if s.handler == nil || s.handler.Hub() == nil {
-		return nil, 0, ErrServerNotInitialized
+		return nil, ErrServerNotInitialized
 	}
 
 	return s.handler.Hub().CreateRoom("__SERVER__", name)

--- a/server.go
+++ b/server.go
@@ -582,7 +582,7 @@ func (s *Server) GetRooms() []string {
 	hubRooms := s.handler.Hub().GetRooms()
 	rooms := make([]string, 0, len(hubRooms))
 	for _, room := range hubRooms {
-		rooms = append(rooms, room.Name)
+		rooms = append(rooms, room.Name())
 	}
 
 	return rooms

--- a/server.go
+++ b/server.go
@@ -490,9 +490,9 @@ func (s *Server) BroadcastToRoomProtobuf(room string, data interface{}) error {
 
 // GetClients returns all clients currently connected to the server. If the server is not properly
 // initialized, an empty slice is returned.
-func (s *Server) GetClients() []*Client {
+func (s *Server) GetClients() map[uint64]*Client {
 	if s.handler == nil || s.handler.Hub() == nil {
-		return []*Client{}
+		return map[uint64]*Client{}
 	}
 
 	return s.handler.Hub().GetClients()
@@ -512,12 +512,12 @@ func (s *Server) GetClient(id string) *Client {
 // GetClientsInRoom returns all clients in the specified room. If the server is not properly
 // initialized or the room does not exist, an empty slice is returned. This method is safe to call
 // concurrently.
-func (s *Server) GetClientsInRoom(room string) []*Client {
+func (s *Server) GetClientsInRoom(room string) map[uint64]*Client {
 	if s.handler == nil || s.handler.Hub() == nil {
-		return []*Client{}
+		return map[uint64]*Client{}
 	}
 
-	return s.handler.Hub().GetRoomClients(room)
+	return s.handler.Hub().GetClientsInRoom(room)
 }
 
 // GetClientCount returns the number of clients currently connected to the server. If the server is not properly
@@ -550,9 +550,9 @@ func (s *Server) DisconnectClient(id string) error {
 // will return nil. If the server is not properly initialized, an error is returned.
 //
 // Thismethod is safe to call concurrently.
-func (s *Server) CreateRoom(name string) (*Room, error) {
+func (s *Server) CreateRoom(name string) (*Room, uint64, error) {
 	if s.handler == nil || s.handler.Hub() == nil {
-		return nil, ErrServerNotInitialized
+		return nil, 0, ErrServerNotInitialized
 	}
 
 	return s.handler.Hub().CreateRoom("__SERVER__", name)

--- a/server.go
+++ b/server.go
@@ -442,9 +442,7 @@ func (s *Server) BroadcastToRoom(room string, message []byte) error {
 
 	msg := NewRawMessage(TextMessage, message)
 	msg.Room = room
-	s.handler.Hub().BroadcastToRoom(room, msg)
-
-	return nil
+	return s.handler.Hub().BroadcastToRoom(room, msg)
 }
 
 // BroadcastToRoomData sends the given data to all clients in the specified room. The data
@@ -686,9 +684,8 @@ func (s *Server) notifyClientsShutdown() {
 			defer cancel()
 
 			select {
-			case c.MessageChan <- func() []byte {
-				data, _ := json.Marshal(shutdownMessage)
-				return data
+			case c.MessageChan <- func() *Message {
+				return NewMessageWithEncoding(TextMessage, shutdownMessage, JSON)
 			}():
 			case <-ctx.Done():
 				_ = c.Disconnect()

--- a/server_test.go
+++ b/server_test.go
@@ -1015,8 +1015,8 @@ func TestServer_GetClients(t *testing.T) {
 				client1 := NewClient("client1", &MockWebSocketConn{}, hub, server.handler.config.MessageChanBufSize)
 				client2 := NewClient("client2", &MockWebSocketConn{}, hub, server.handler.config.MessageChanBufSize)
 
-				hub.Clients.AddWithStringId(client1, client1.ID)
-				hub.Clients.AddWithStringId(client2, client2.ID)
+				hub.Clients.Add(client1, client1.ID)
+				hub.Clients.Add(client2, client2.ID)
 
 				server.handler.SetHub(hub)
 				return server
@@ -1052,7 +1052,7 @@ func TestServer_GetClient(t *testing.T) {
 				hub := NewHub(DefaultLoggerConfig())
 
 				client := NewClient("test-client", &MockWebSocketConn{}, hub, server.handler.config.MessageChanBufSize)
-				hub.Clients.AddWithStringId(client, client.ID)
+				hub.Clients.Add(client, client.ID)
 
 				server.handler.SetHub(hub)
 				return server
@@ -1123,9 +1123,9 @@ func TestServer_GetClientCount(t *testing.T) {
 				client2 := NewClient("client2", &MockWebSocketConn{}, hub, server.handler.config.MessageChanBufSize)
 				client3 := NewClient("client3", &MockWebSocketConn{}, hub, server.handler.config.MessageChanBufSize)
 
-				hub.Clients.AddWithStringId(client1, client1.ID)
-				hub.Clients.AddWithStringId(client2, client2.ID)
-				hub.Clients.AddWithStringId(client3, client3.ID)
+				hub.Clients.Add(client1, client1.ID)
+				hub.Clients.Add(client2, client2.ID)
+				hub.Clients.Add(client3, client3.ID)
 
 				server.handler.SetHub(hub)
 				return server
@@ -1199,7 +1199,7 @@ func TestServer_RoomManagement(t *testing.T) {
 				mockHub.On("DeleteRoom", "test-room").Return(nil)
 				mockHub.On("Log", mock.AnythingOfType("LogType"), mock.AnythingOfType("LogLevel"), mock.AnythingOfType("string"), mock.AnythingOfType("[]interface {}"))
 				server.handler.SetHub(mockHub)
-				_, _, _ = server.CreateRoom("test-room")
+				_, _ = server.CreateRoom("test-room")
 				return server
 			},
 			operation:       "delete",
@@ -1232,7 +1232,7 @@ func TestServer_RoomManagement(t *testing.T) {
 			var err error
 			switch tt.operation {
 			case "create":
-				_, _, err = server.CreateRoom(tt.roomName)
+				_, err = server.CreateRoom(tt.roomName)
 			case "delete":
 				err = server.DeleteRoom(tt.roomName)
 			}
@@ -1277,9 +1277,9 @@ func TestServer_GetRooms(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				_, _, _ = server.CreateRoom("room1")
-				_, _, _ = server.CreateRoom("room2")
-				_, _, _ = server.CreateRoom("room3")
+				_, _ = server.CreateRoom("room1")
+				_, _ = server.CreateRoom("room2")
+				_, _ = server.CreateRoom("room3")
 
 				return server
 			},
@@ -1317,7 +1317,7 @@ func TestServer_ClientRoomOperations(t *testing.T) {
 				hub := NewHub(DefaultLoggerConfig())
 
 				client := NewClient("test-client", &MockWebSocketConn{}, hub, server.handler.config.MessageChanBufSize)
-				hub.Clients.AddWithStringId(client, client.ID)
+				hub.Clients.Add(client, client.ID)
 
 				server.handler.SetHub(hub)
 				return server
@@ -1354,7 +1354,7 @@ func TestServer_ClientRoomOperations(t *testing.T) {
 				hub := NewHub(DefaultLoggerConfig())
 
 				client := NewClient("test-client", &MockWebSocketConn{}, hub, server.handler.config.MessageChanBufSize)
-				hub.Clients.AddWithStringId(client, client.ID)
+				hub.Clients.Add(client, client.ID)
 
 				server.handler.SetHub(hub)
 				return server
@@ -1430,7 +1430,7 @@ func TestServer_DisconnectClient(t *testing.T) {
 				// Mock the hub methods that will be called during disconnect
 				mockHub.On("RemoveClient", client).Return()
 				mockHub.On("GetClients")
-				mockHub.Clients.AddWithStringId(client, client.ID)
+				mockHub.Clients.Add(client, client.ID)
 
 				server.handler.SetHub(mockHub)
 				return server
@@ -1448,7 +1448,7 @@ func TestServer_DisconnectClient(t *testing.T) {
 				mockHub := NewMockHub()
 
 				mockHub.On("GetClients")
-				mockHub.Clients = NewSharedCollection[*Client]() // Empty clients collection
+				mockHub.Clients = NewSharedCollection[*Client, string]() // Empty clients collection
 				server.handler.SetHub(mockHub)
 				return server
 			},

--- a/server_test.go
+++ b/server_test.go
@@ -1319,6 +1319,8 @@ func TestServer_ClientRoomOperations(t *testing.T) {
 				client := NewClient("test-client", &MockWebSocketConn{}, hub, server.handler.config.MessageChanBufSize)
 				hub.Clients.Add(client, client.ID)
 
+				_, _ = hub.CreateRoom("test-client", "test-room")
+
 				server.handler.SetHub(hub)
 				return server
 			},

--- a/server_test.go
+++ b/server_test.go
@@ -1199,7 +1199,7 @@ func TestServer_RoomManagement(t *testing.T) {
 				mockHub.On("DeleteRoom", "test-room").Return(nil)
 				mockHub.On("Log", mock.AnythingOfType("LogType"), mock.AnythingOfType("LogLevel"), mock.AnythingOfType("string"), mock.AnythingOfType("[]interface {}"))
 				server.handler.SetHub(mockHub)
-				_, _ = server.CreateRoom("test-room")
+				_, _, _ = server.CreateRoom("test-room")
 				return server
 			},
 			operation:       "delete",
@@ -1232,7 +1232,7 @@ func TestServer_RoomManagement(t *testing.T) {
 			var err error
 			switch tt.operation {
 			case "create":
-				_, err = server.CreateRoom(tt.roomName)
+				_, _, err = server.CreateRoom(tt.roomName)
 			case "delete":
 				err = server.DeleteRoom(tt.roomName)
 			}
@@ -1277,9 +1277,9 @@ func TestServer_GetRooms(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				_, _ = server.CreateRoom("room1")
-				_, _ = server.CreateRoom("room2")
-				_, _ = server.CreateRoom("room3")
+				_, _, _ = server.CreateRoom("room1")
+				_, _, _ = server.CreateRoom("room2")
+				_, _, _ = server.CreateRoom("room3")
 
 				return server
 			},

--- a/utils.go
+++ b/utils.go
@@ -15,6 +15,7 @@ var clientCounter atomic.Uint64
 
 type Middleware func(http.Handler) http.Handler
 type AuthFunc func(*http.Request) (map[string]interface{}, error)
+type ClientIdGenerator func(r *http.Request, userData map[string]interface{}) (string, error)
 type UniversalOption func(HasHandler) error
 
 type HasHandler interface {


### PR DESCRIPTION
# Pull Request

## Description
- MessageChan now receives a *Message
- Add SendToClient method
- Add GetClient method
- BroadcastToRoom now returns an error
- Handler now serialize based on encoding
- Add WithCustomClientId: allow the ID in Client be custom
- Rename GetRoomClients to GetClientsInRoom
- Add GetRoomById
- Return maps instead array at GetClientsInRoom, GetClients and GetRooms: you can easily find the obj by the id
- CreateRoom return the SharedCollection id
- Room vars as private
- Room id as string
- Room actions with room id, not room name
